### PR TITLE
Updated coap service to be compatible with mbed TLS 3.0

### DIFF
--- a/source/coap_security_handler.c
+++ b/source/coap_security_handler.c
@@ -386,7 +386,9 @@ static int coap_security_handler_configure_keys(coap_security_t *sec, coap_secur
             mbedtls_ssl_conf_ciphersuites(&sec->_conf, ECJPAKE_SUITES);
 #endif /* !defined(MBEDTLS_SSL_CONF_SINGLE_CIPHERSUITE) */
 
-#if (MBEDTLS_VERSION_MAJOR < 3)
+#if (MBEDTLS_VERSION_MAJOR >= 3)
+            tr_error("FATAL ERROR: support for mbedtls_ssl_set_export_keys_cb() not implemented");
+#else
             //NOTE: If thread starts supporting PSK in other modes, then this will be needed!
             mbedtls_ssl_conf_export_keys_cb(&sec->_conf,
                                             export_key_block,

--- a/source/coap_security_handler.c
+++ b/source/coap_security_handler.c
@@ -23,12 +23,12 @@
 
 #ifdef COAP_SECURITY_AVAILABLE
 
+#include "mbedtls/version.h"
 #include "mbedtls/sha256.h"
 #include "mbedtls/error.h"
 #include "mbedtls/platform.h"
 #include "mbedtls/ssl_cookie.h"
 #include "mbedtls/entropy.h"
-#include "mbedtls/entropy_poll.h"
 #include "mbedtls/ctr_drbg.h"
 #include "mbedtls/hmac_drbg.h"
 #include "mbedtls/ssl_ciphersuites.h"
@@ -310,6 +310,7 @@ static int simple_cookie_check(void *ctx,
 
 /**** Key export function ****/
 #if defined(MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED)
+#if (MBEDTLS_VERSION_MAJOR < 3)
 static int export_key_block(void *ctx,
                             const unsigned char *mk, const unsigned char *kb,
                             size_t maclen, size_t keylen, size_t ivlen)
@@ -330,6 +331,7 @@ static int export_key_block(void *ctx,
     return 0;
 }
 #endif
+#endif
 
 static int coap_security_handler_configure_keys(coap_security_t *sec, coap_security_keys_t keys, bool is_server)
 {
@@ -343,9 +345,15 @@ static int coap_security_handler_configure_keys(coap_security_t *sec, coap_secur
                 break;
             }
 
+#if (MBEDTLS_VERSION_MAJOR >= 3)
+            if (mbedtls_pk_parse_key(&sec->_pkey, keys._priv_key, keys._priv_key_len, NULL, 0, DRBG_RANDOM, &sec->_drbg) < 0) {
+                break;
+            }
+#else
             if (mbedtls_pk_parse_key(&sec->_pkey, keys._priv_key, keys._priv_key_len, NULL, 0) < 0) {
                 break;
             }
+#endif
 
             if (0 != mbedtls_ssl_conf_own_cert(&sec->_conf, &sec->_owncert, &sec->_pkey)) {
                 break;
@@ -378,10 +386,13 @@ static int coap_security_handler_configure_keys(coap_security_t *sec, coap_secur
             mbedtls_ssl_conf_ciphersuites(&sec->_conf, ECJPAKE_SUITES);
 #endif /* !defined(MBEDTLS_SSL_CONF_SINGLE_CIPHERSUITE) */
 
+#if (MBEDTLS_VERSION_MAJOR < 3)
             //NOTE: If thread starts supporting PSK in other modes, then this will be needed!
             mbedtls_ssl_conf_export_keys_cb(&sec->_conf,
                                             export_key_block,
                                             &sec->_keyblk);
+#endif
+
             ret = 0;
 #endif
             break;
@@ -512,9 +523,15 @@ int coap_security_handler_continue_connecting(coap_security_t *sec)
             return ret;
         }
 
+#if (MBEDTLS_VERSION_MAJOR >= 3)
+        if (sec->_ssl.private_state == MBEDTLS_SSL_HANDSHAKE_OVER) {
+            return 0;
+        }
+#else
         if (sec->_ssl.state == MBEDTLS_SSL_HANDSHAKE_OVER) {
             return 0;
         }
+#endif
     }
 
     if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE) {

--- a/source/include/coap_security_handler.h
+++ b/source/include/coap_security_handler.h
@@ -20,12 +20,8 @@
 #include "ns_types.h"
 
 #ifdef NS_USE_EXTERNAL_MBED_TLS
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
 // cppcheck-suppress preprocessorErrorDirective
-#include MBEDTLS_CONFIG_FILE
-#endif
+#include "mbedtls/version.h"
 
 #if defined(MBEDTLS_SSL_TLS_C)
 #include "mbedtls/ssl.h"

--- a/test/coap-service/unittest/coap_security_handler/test_coap_security_handler.c
+++ b/test/coap-service/unittest/coap_security_handler/test_coap_security_handler.c
@@ -184,7 +184,7 @@ bool test_coap_security_handler_connect()
     }
 
     mbedtls_stub.counter = 0;
-    mbedtls_stub.retArray[5] = MBEDTLS_ERR_SSL_BAD_HS_FINISHED;
+    mbedtls_stub.retArray[5] = MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL;
 
     if (-1 != coap_security_handler_connect_non_blocking(handle, true, DTLS, keys, 0, 1)) {
         return false;
@@ -230,9 +230,9 @@ bool test_coap_security_handler_continue_connecting()
     }
 
     mbedtls_stub.counter = 0;
-    mbedtls_stub.retArray[0] = MBEDTLS_ERR_SSL_BAD_HS_FINISHED;
+    mbedtls_stub.retArray[0] = MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL;
 
-    if (MBEDTLS_ERR_SSL_BAD_HS_FINISHED != coap_security_handler_continue_connecting(handle)) {
+    if (MBEDTLS_ERR_SSL_BUFFER_TOO_SMALL != coap_security_handler_continue_connecting(handle)) {
         return false;
     }
 

--- a/test/coap-service/unittest/stub/mbedtls_stub.c
+++ b/test/coap-service/unittest/stub/mbedtls_stub.c
@@ -27,8 +27,11 @@ int mbedtls_ssl_handshake_step(mbedtls_ssl_context *ssl)
 
         if (mbedtls_stub.retArray[mbedtls_stub.counter] == HANDSHAKE_FINISHED_VALUE ||
                 mbedtls_stub.retArray[mbedtls_stub.counter] == HANDSHAKE_FINISHED_VALUE_RETURN_ZERO) {
-
+#if (MBEDTLS_VERSION_MAJOR >= 3)
+            ssl->private_state = MBEDTLS_SSL_HANDSHAKE_OVER;
+#else
             ssl->state = MBEDTLS_SSL_HANDSHAKE_OVER;
+#endif
             if (mbedtls_stub.retArray[mbedtls_stub.counter] == HANDSHAKE_FINISHED_VALUE_RETURN_ZERO) {
                 return 0;
             }
@@ -346,9 +349,17 @@ int mbedtls_entropy_add_source(mbedtls_entropy_context *a,
 }
 
 //From pk.h
+#if (MBEDTLS_VERSION_MAJOR >= 3)
+int mbedtls_pk_parse_key( mbedtls_pk_context *ctx,
+              const unsigned char *b, size_t c,
+              const unsigned char *d, size_t e,
+              int (*f_rng)(void *, unsigned char *, size_t), void *p_rng )
+
+#else
 int mbedtls_pk_parse_key(mbedtls_pk_context *a,
                          const unsigned char *b, size_t c,
                          const unsigned char *d, size_t e)
+#endif
 {
     if (mbedtls_stub.useCounter) {
         return mbedtls_stub.retArray[mbedtls_stub.counter++];
@@ -396,6 +407,7 @@ void mbedtls_ssl_conf_dtls_cookies(mbedtls_ssl_config *conf,
     }
 }
 
+#if (MBEDTLS_VERSION_MAJOR < 3)
 void mbedtls_ssl_conf_export_keys_cb(mbedtls_ssl_config *conf,
                                      mbedtls_ssl_export_keys_t *f_export_keys,
                                      void *p_export_keys)
@@ -408,6 +420,7 @@ void mbedtls_ssl_conf_export_keys_cb(mbedtls_ssl_config *conf,
         f_export_keys(p_export_keys, &value, "", 0, 20, 0); //success case
     }
 }
+#endif
 
 int mbedtls_ssl_session_reset(mbedtls_ssl_context *ssl)
 {

--- a/test/coap-service/unittest/stub/mbedtls_stub.c
+++ b/test/coap-service/unittest/stub/mbedtls_stub.c
@@ -350,11 +350,10 @@ int mbedtls_entropy_add_source(mbedtls_entropy_context *a,
 
 //From pk.h
 #if (MBEDTLS_VERSION_MAJOR >= 3)
-int mbedtls_pk_parse_key( mbedtls_pk_context *ctx,
-              const unsigned char *b, size_t c,
-              const unsigned char *d, size_t e,
-              int (*f_rng)(void *, unsigned char *, size_t), void *p_rng )
-
+int mbedtls_pk_parse_key(mbedtls_pk_context *ctx,
+                         const unsigned char *b, size_t c,
+                         const unsigned char *d, size_t e,
+                         int (*f_rng)(void *, unsigned char *, size_t), void *p_rng)
 #else
 int mbedtls_pk_parse_key(mbedtls_pk_context *a,
                          const unsigned char *b, size_t c,


### PR DESCRIPTION
Disabled key material export for now, needs to be updated later to new key export function if needed. Made the SSL state to refer to private state for now. Do not include config, instead include version.h that is present in both 2.0 and 3.0 and will include config and defines version macros.